### PR TITLE
Fix parsing quoted fields containing semicolons or escaped quotes

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -269,7 +269,14 @@ class Query(object):
                 if len(sqlFragments) == 1:
                     sqlStatement += line + ' '
                 else:
+                    quotes = 0
                     for sqlFragment in sqlFragments:
+                        quotes += sqlFragment.count('\'')
+                        quotes -= sqlFragment.count('\\\'')
+                        if quotes % 2 != 0:
+                            sqlStatement += sqlFragment + ';'
+                            continue
+                        
                         sqlFragment = sqlFragment.strip()
                         if len(sqlFragment) == 0:
                             continue
@@ -278,6 +285,7 @@ class Query(object):
 
                         self.__execute_sql(cur, sqlStatement)
                         sqlStatement = ''
+                        quotes = 0
 
             sqlStatement = sqlStatement.strip()
             if len(sqlStatement) != 0:


### PR DESCRIPTION
Make Execute Sql Script process correctly ";" and "\\'" in statements as:

`
INSERT INTO a VALUES ('style=\"--bs-table-bg: transparent; --bs-table-striped-color: transparent;\"' , 'D\'Paula');
`

This should fix issue #111.