### PR TITLE
add support for renamed oracle driver

### DIFF
--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -122,7 +122,7 @@ class ConnectionManager(object):
             dbPort = dbPort or 50000
             logger.info('Connecting using : %s.connect(DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=%s;) ' % (dbapiModuleName, dbName, dbHost, dbPort, dbUsername, dbPassword))
             self._dbconnection = db_api_2.connect('DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=%s;' % (dbName, dbHost, dbPort, dbUsername, dbPassword), '', '')
-        elif dbapiModuleName in ["cx_Oracle"]:
+        elif dbapiModuleName in ["cx_Oracle", "oracledb"]:
             dbPort = dbPort or 1521
             oracle_dsn =  db_api_2.makedsn(host=dbHost, port=dbPort, service_name=dbName)
             logger.info('Connecting using: %s.connect(user=%s, password=%s, dsn=%s) ' % (dbapiModuleName, dbUsername, dbPassword, oracle_dsn))


### PR DESCRIPTION
cx_Oracle driver has been renamed oracledb in newer versions, see https://pypi.org/project/oracledb/