### PR TITLE
Add precommit configuration and refactor files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      name: isort (python)
+
+- repo: https://github.com/psf/black
+  rev: 23.1.0
+  hooks:
+  - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,10 @@ dynamic = ["version"]
 
 [tool.setuptools.dynamic]
 version = {attr = "DatabaseLibrary.__version__"}
+
+[tool.black]
+line-length = 120
+
+[tool.isort]
+profile = "black"
+line_length = 120

--- a/src/DatabaseLibrary/__init__.py
+++ b/src/DatabaseLibrary/__init__.py
@@ -14,17 +14,18 @@
 
 import os
 
+from DatabaseLibrary.assertion import Assertion
 from DatabaseLibrary.connection_manager import ConnectionManager
 from DatabaseLibrary.query import Query
-from DatabaseLibrary.assertion import Assertion
 from DatabaseLibrary.version import VERSION
 
 __version__ = VERSION
 
+
 class DatabaseLibrary(ConnectionManager, Query, Assertion):
     """
     The Database Library for [https://robotframework.org|Robot Framework] allows you to query a database and verify the results.
-    It requires an appropriate *Python module to be installed separately* - depending on your database, like e.g. `oracledb` or `pymysql`. 
+    It requires an appropriate *Python module to be installed separately* - depending on your database, like e.g. `oracledb` or `pymysql`.
 
     == Requirements ==
     - Python
@@ -36,11 +37,11 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     Don't forget to install the required Python database module!
 
     == Usage example ==
-    
+
     | *** Settings ***
     | Library       DatabaseLibrary
     | Test Setup    Connect To My Oracle DB
-    | 
+    |
     | *** Keywords ***
     | Connect To My Oracle DB
     |     Connect To Database
@@ -50,19 +51,19 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     |     ...    dbPassword=my_pass
     |     ...    dbHost=127.0.0.1
     |     ...    dbPort=1521
-    | 
+    |
     | *** Test Cases ***
     | Person Table Contains Expected Records
     |     ${output}=    Query    select LAST_NAME from person
     |     Length Should Be    ${output}    2
     |     Should Be Equal    ${output}[0][0]    See
     |     Should Be Equal    ${output}[1][0]    Schneider
-    | 
+    |
     | Person Table Contains No Joe
     |     ${sql}=    Catenate    SELECT id FROM person
-    |     ...                    WHERE FIRST_NAME= 'Joe'    
+    |     ...                    WHERE FIRST_NAME= 'Joe'
     |     Check If Not Exists In Database    ${sql}
-    | 
+    |
 
     == Database modules compatibility ==
     The library is basically compatible with any [https://peps.python.org/pep-0249|Python Database API Specification 2.0] module.
@@ -73,4 +74,4 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     See more on the [https://github.com/MarketSquare/Robotframework-Database-Library|project page on GitHub].
     """
 
-    ROBOT_LIBRARY_SCOPE = 'GLOBAL'
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"

--- a/src/DatabaseLibrary/assertion.py
+++ b/src/DatabaseLibrary/assertion.py
@@ -15,7 +15,7 @@
 from robot.api import logger
 
 
-class Assertion(object):
+class Assertion:
     """
     Assertion handles all the assertions of Database Library.
     """
@@ -44,10 +44,11 @@ class Assertion(object):
         Using optional `msg` to override the default error message:
         | Check If Exists In Database | SELECT id FROM person WHERE first_name = 'John' | msg=my error message |
         """
-        logger.info (f"Executing : Check If Exists In Database  |  {selectStatement}")
+        logger.info(f"Executing : Check If Exists In Database  |  {selectStatement}")
         if not self.query(selectStatement, sansTran):
-            raise AssertionError(msg or f"Expected to have have at least one row, "
-                                 f"but got 0 rows from: '{selectStatement}'")
+            raise AssertionError(
+                msg or f"Expected to have have at least one row, " f"but got 0 rows from: '{selectStatement}'"
+            )
 
     def check_if_not_exists_in_database(self, selectStatement, sansTran=False, msg=None):
         """
@@ -78,8 +79,9 @@ class Assertion(object):
         logger.info(f"Executing : Check If Not Exists In Database  |  {selectStatement}")
         queryResults = self.query(selectStatement, sansTran)
         if queryResults:
-            raise AssertionError(msg or f"Expected to have have no rows from '{selectStatement}', "
-                                        f"but got some rows: {queryResults}")
+            raise AssertionError(
+                msg or f"Expected to have have no rows from '{selectStatement}', but got some rows: {queryResults}"
+            )
 
     def row_count_is_0(self, selectStatement, sansTran=False, msg=None):
         """
@@ -137,9 +139,10 @@ class Assertion(object):
         """
         logger.info(f"Executing : Row Count Is Equal To X  |  {selectStatement}  |  {numRows}")
         num_rows = self.row_count(selectStatement, sansTran)
-        if num_rows != int(numRows.encode('ascii')):
-            raise AssertionError(msg or f"Expected {numRows} rows, "
-                                 f"but {num_rows} were returned from: '{selectStatement}'")
+        if num_rows != int(numRows.encode("ascii")):
+            raise AssertionError(
+                msg or f"Expected {numRows} rows, but {num_rows} were returned from: '{selectStatement}'"
+            )
 
     def row_count_is_greater_than_x(self, selectStatement, numRows, sansTran=False, msg=None):
         """
@@ -168,9 +171,10 @@ class Assertion(object):
         """
         logger.info(f"Executing : Row Count Is Greater Than X  |  {selectStatement}  |  {numRows}")
         num_rows = self.row_count(selectStatement, sansTran)
-        if num_rows <= int(numRows.encode('ascii')):
-            raise AssertionError(msg or f"Expected more than {numRows} rows, "
-                                 f"but {num_rows} were returned from '{selectStatement}'")
+        if num_rows <= int(numRows.encode("ascii")):
+            raise AssertionError(
+                msg or f"Expected more than {numRows} rows, but {num_rows} were returned from '{selectStatement}'"
+            )
 
     def row_count_is_less_than_x(self, selectStatement, numRows, sansTran=False, msg=None):
         """
@@ -199,9 +203,10 @@ class Assertion(object):
         """
         logger.info(f"Executing : Row Count Is Less Than X  |  {selectStatement}  |  {numRows}")
         num_rows = self.row_count(selectStatement, sansTran)
-        if num_rows >= int(numRows.encode('ascii')):
-            raise AssertionError(msg or f"Expected less than {numRows} rows, "
-                                 f"but {num_rows} were returned from '{selectStatement}'")
+        if num_rows >= int(numRows.encode("ascii")):
+            raise AssertionError(
+                msg or f"Expected less than {numRows} rows, but {num_rows} were returned from '{selectStatement}'"
+            )
 
     def table_must_exist(self, tableName, sansTran=False, msg=None):
         """
@@ -223,30 +228,34 @@ class Assertion(object):
         Using optional `msg` to override the default error message:
         | Table Must Exist | first_name | msg=my error message |
         """
-        logger.info('Executing : Table Must Exist  |  %s ' % tableName)
+        logger.info("Executing : Table Must Exist  |  %s " % tableName)
         if self.db_api_module_name in ["cx_Oracle", "oracledb"]:
-            selectStatement = ("SELECT * FROM all_objects WHERE object_type IN ('TABLE','VIEW') AND owner = SYS_CONTEXT('USERENV', 'SESSION_USER') AND object_name = UPPER('%s')" % tableName)
+            selectStatement = (
+                "SELECT * FROM all_objects WHERE object_type IN ('TABLE','VIEW') AND "
+                "owner = SYS_CONTEXT('USERENV', 'SESSION_USER') AND object_name = UPPER('%s')" % tableName
+            )
             table_exists = self.row_count(selectStatement, sansTran) > 0
         elif self.db_api_module_name in ["sqlite3"]:
-            selectStatement = ("SELECT name FROM sqlite_master WHERE type='table' AND name='%s' COLLATE NOCASE" % tableName)
+            selectStatement = (
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='%s' COLLATE NOCASE" % tableName
+            )
             table_exists = self.row_count(selectStatement, sansTran) > 0
         elif self.db_api_module_name in ["ibm_db", "ibm_db_dbi"]:
-            selectStatement = ("SELECT name FROM SYSIBM.SYSTABLES WHERE type='T' AND name=UPPER('%s')" % tableName)
+            selectStatement = "SELECT name FROM SYSIBM.SYSTABLES WHERE type='T' AND name=UPPER('%s')" % tableName
             table_exists = self.row_count(selectStatement, sansTran) > 0
         elif self.db_api_module_name in ["teradata"]:
-            selectStatement = ("SELECT TableName FROM DBC.TablesV WHERE TableKind='T' AND TableName='%s'" % tableName)
+            selectStatement = "SELECT TableName FROM DBC.TablesV WHERE TableKind='T' AND TableName='%s'" % tableName
             table_exists = self.row_count(selectStatement, sansTran) > 0
         else:
             try:
-                selectStatement = (f"SELECT * FROM information_schema.tables WHERE table_name='{tableName}'")
+                selectStatement = f"SELECT * FROM information_schema.tables WHERE table_name='{tableName}'"
                 table_exists = self.row_count(selectStatement, sansTran) > 0
             except:
                 logger.info("Database doesn't support information schema, try using a simple SQL request")
                 try:
-                    selectStatement = (f"SELECT 1 from {tableName} where 1=0")
+                    selectStatement = f"SELECT 1 from {tableName} where 1=0"
                     num_rows = self.row_count(selectStatement, sansTran)
                     table_exists = True
                 except:
                     table_exists = False
         assert table_exists, msg or f"Table '{tableName}' does not exist in the db"
-

--- a/src/DatabaseLibrary/connection_manager.py
+++ b/src/DatabaseLibrary/connection_manager.py
@@ -22,7 +22,7 @@ except:
 from robot.api import logger
 
 
-class ConnectionManager(object):
+class ConnectionManager:
     """
     Connection Manager handles the connection & disconnection to the database.
     """
@@ -35,7 +35,18 @@ class ConnectionManager(object):
         self.db_api_module_name = None
         self.omit_trailing_semicolon = False
 
-    def connect_to_database(self, dbapiModuleName=None, dbName=None, dbUsername=None, dbPassword=None, dbHost=None, dbPort=None, dbCharset=None, dbDriver=None, dbConfigFile=None):
+    def connect_to_database(
+        self,
+        dbapiModuleName=None,
+        dbName=None,
+        dbUsername=None,
+        dbPassword=None,
+        dbHost=None,
+        dbPort=None,
+        dbCharset=None,
+        dbDriver=None,
+        dbConfigFile=None,
+    ):
         """
         Loads the DB API 2.0 module given `dbapiModuleName` then uses it to
         connect to the database using `dbName`, `dbUsername`, and `dbPassword`.
@@ -81,12 +92,12 @@ class ConnectionManager(object):
         config = ConfigParser.ConfigParser()
         config.read([dbConfigFile])
 
-        dbapiModuleName = dbapiModuleName or config.get('default', 'dbapiModuleName')
-        dbName = dbName or config.get('default', 'dbName')
-        dbUsername = dbUsername or config.get('default', 'dbUsername')
-        dbPassword = dbPassword if dbPassword is not None else config.get('default', 'dbPassword')
-        dbHost = dbHost or config.get('default', 'dbHost') or 'localhost'
-        dbPort = int(dbPort or config.get('default', 'dbPort'))
+        dbapiModuleName = dbapiModuleName or config.get("default", "dbapiModuleName")
+        dbName = dbName or config.get("default", "dbName")
+        dbUsername = dbUsername or config.get("default", "dbUsername")
+        dbPassword = dbPassword if dbPassword is not None else config.get("default", "dbPassword")
+        dbHost = dbHost or config.get("default", "dbHost") or "localhost"
+        dbPort = int(dbPort or config.get("default", "dbPort"))
 
         if dbapiModuleName == "excel" or dbapiModuleName == "excelrw":
             self.db_api_module_name = "pyodbc"
@@ -97,15 +108,34 @@ class ConnectionManager(object):
 
         if dbapiModuleName in ["MySQLdb", "pymysql"]:
             dbPort = dbPort or 3306
-            logger.info('Connecting using : %s.connect(db=%s, user=%s, passwd=***, host=%s, port=%s, charset=%s) ' % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort, dbCharset))
-            self._dbconnection = db_api_2.connect(db=dbName, user=dbUsername, passwd=dbPassword, host=dbHost, port=dbPort, charset='utf8mb4' or dbCharset)
+            logger.info(
+                "Connecting using : %s.connect(db=%s, user=%s, passwd=***, host=%s, port=%s, charset=%s) "
+                % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort, dbCharset)
+            )
+            self._dbconnection = db_api_2.connect(
+                db=dbName,
+                user=dbUsername,
+                passwd=dbPassword,
+                host=dbHost,
+                port=dbPort,
+                charset="utf8mb4" or dbCharset,
+            )
         elif dbapiModuleName in ["psycopg2"]:
             dbPort = dbPort or 5432
-            logger.info('Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) ' % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort))
-            self._dbconnection = db_api_2.connect(database=dbName, user=dbUsername, password=dbPassword, host=dbHost, port=dbPort)
+            logger.info(
+                "Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) "
+                % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort)
+            )
+            self._dbconnection = db_api_2.connect(
+                database=dbName,
+                user=dbUsername,
+                password=dbPassword,
+                host=dbHost,
+                port=dbPort,
+            )
         elif dbapiModuleName in ["pyodbc", "pypyodbc"]:
             dbPort = dbPort or 1433
-            dbCharset = dbCharset or 'utf8mb4'
+            dbCharset = dbCharset or "utf8mb4"
             dbDriver = dbDriver or "{SQL Server}"
             con_str = f"DRIVER={dbDriver};DATABASE={dbName};UID={dbUsername};PWD={dbPassword};charset={dbCharset};"
             if "mysql" in dbDriver.lower():
@@ -116,38 +146,61 @@ class ConnectionManager(object):
             self._dbconnection = db_api_2.connect(con_str)
         elif dbapiModuleName in ["excel"]:
             logger.info(
-                'Connecting using : %s.connect(DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=1;Extended Properties="Excel 8.0;HDR=YES";)' % (
-                dbapiModuleName, dbName))
+                'Connecting using : %s.connect(DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=1;Extended Properties="Excel 8.0;HDR=YES";)'
+                % (dbapiModuleName, dbName)
+            )
             self._dbconnection = db_api_2.connect(
-                'DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=1;Extended Properties="Excel 8.0;HDR=YES";)' % (
-                    dbName), autocommit=True)
+                'DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=1;Extended Properties="Excel 8.0;HDR=YES";)'
+                % (dbName),
+                autocommit=True,
+            )
         elif dbapiModuleName in ["excelrw"]:
             logger.info(
-                'Connecting using : %s.connect(DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=0;Extended Properties="Excel 8.0;HDR=YES";)' % (
-                dbapiModuleName, dbName))
+                'Connecting using : %s.connect(DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=0;Extended Properties="Excel 8.0;HDR=YES";)'
+                % (dbapiModuleName, dbName)
+            )
             self._dbconnection = db_api_2.connect(
-                'DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=0;Extended Properties="Excel 8.0;HDR=YES";)' % (
-                    dbName), autocommit=True)
+                'DRIVER={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)};DBQ=%s;ReadOnly=0;Extended Properties="Excel 8.0;HDR=YES";)'
+                % (dbName),
+                autocommit=True,
+            )
         elif dbapiModuleName in ["ibm_db", "ibm_db_dbi"]:
             dbPort = dbPort or 50000
-            logger.info('Connecting using : %s.connect(DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=***;) ' % (dbapiModuleName, dbName, dbHost, dbPort, dbUsername))
-            self._dbconnection = db_api_2.connect('DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=%s;' % (dbName, dbHost, dbPort, dbUsername, dbPassword), '', '')
+            logger.info(
+                "Connecting using : %s.connect(DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=***;) "
+                % (dbapiModuleName, dbName, dbHost, dbPort, dbUsername)
+            )
+            self._dbconnection = db_api_2.connect(
+                "DATABASE=%s;HOSTNAME=%s;PORT=%s;PROTOCOL=TCPIP;UID=%s;PWD=%s;"
+                % (dbName, dbHost, dbPort, dbUsername, dbPassword),
+                "",
+                "",
+            )
         elif dbapiModuleName in ["cx_Oracle"]:
             dbPort = dbPort or 1521
-            oracle_dsn =  db_api_2.makedsn(host=dbHost, port=dbPort, service_name=dbName)
-            logger.info('Connecting using: %s.connect(user=%s, password=***, dsn=%s) ' % (dbapiModuleName, dbUsername, oracle_dsn))
+            oracle_dsn = db_api_2.makedsn(host=dbHost, port=dbPort, service_name=dbName)
+            logger.info(
+                "Connecting using: %s.connect(user=%s, password=***, dsn=%s) "
+                % (dbapiModuleName, dbUsername, oracle_dsn)
+            )
             self._dbconnection = db_api_2.connect(user=dbUsername, password=dbPassword, dsn=oracle_dsn)
             self.omit_trailing_semicolon = True
         elif dbapiModuleName in ["oracledb"]:
             dbPort = dbPort or 1521
-            oracle_connection_params =  db_api_2.ConnectParams(host=dbHost, port=dbPort, service_name=dbName)
-            logger.info('Connecting using: %s.connect(user=%s, password=***, params=%s) ' % (dbapiModuleName, dbUsername, oracle_connection_params))
+            oracle_connection_params = db_api_2.ConnectParams(host=dbHost, port=dbPort, service_name=dbName)
+            logger.info(
+                "Connecting using: %s.connect(user=%s, password=***, params=%s) "
+                % (dbapiModuleName, dbUsername, oracle_connection_params)
+            )
             self._dbconnection = db_api_2.connect(user=dbUsername, password=dbPassword, params=oracle_connection_params)
             self.omit_trailing_semicolon = True
         elif dbapiModuleName in ["teradata"]:
             dbPort = dbPort or 1025
             teradata_udaExec = db_api_2.UdaExec(appName="RobotFramework", version="1.0", logConsole=False)
-            logger.info('Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) ' % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort))
+            logger.info(
+                "Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) "
+                % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort)
+            )
             self._dbconnection = teradata_udaExec.connect(
                 method="odbc",
                 system=dbHost,
@@ -155,28 +208,44 @@ class ConnectionManager(object):
                 username=dbUsername,
                 password=dbPassword,
                 host=dbHost,
-                port=dbPort
+                port=dbPort,
             )
         elif dbapiModuleName in ["ksycopg2"]:
             dbPort = dbPort or 54321
-            logger.info('Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) ' % (
-            dbapiModuleName, dbName, dbUsername, dbHost, dbPort))
-            self._dbconnection = db_api_2.connect(database=dbName, user=dbUsername, password=dbPassword, host=dbHost,
-                                                  port=dbPort)
+            logger.info(
+                "Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) "
+                % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort)
+            )
+            self._dbconnection = db_api_2.connect(
+                database=dbName,
+                user=dbUsername,
+                password=dbPassword,
+                host=dbHost,
+                port=dbPort,
+            )
         else:
-            logger.info('Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) ' % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort))
-            self._dbconnection = db_api_2.connect(database=dbName, user=dbUsername, password=dbPassword, host=dbHost, port=dbPort)
+            logger.info(
+                "Connecting using : %s.connect(database=%s, user=%s, password=***, host=%s, port=%s) "
+                % (dbapiModuleName, dbName, dbUsername, dbHost, dbPort)
+            )
+            self._dbconnection = db_api_2.connect(
+                database=dbName,
+                user=dbUsername,
+                password=dbPassword,
+                host=dbHost,
+                port=dbPort,
+            )
 
-    def connect_to_database_using_custom_params(self, dbapiModuleName=None, db_connect_string=''):
+    def connect_to_database_using_custom_params(self, dbapiModuleName=None, db_connect_string=""):
         """
         Loads the DB API 2.0 module given `dbapiModuleName` then uses it to
         connect to the database using the map string `db_connect_string`
         (parsed as a list of named arguments).
-        
+
         Use `connect_to_database_using_custom_connection_string` for passing
         all params in a single connection string or URI.
 
-        Example usage:        
+        Example usage:
         | Connect To Database Using Custom Params | psycopg2 | database='my_db_test', user='postgres', password='s3cr3t', host='tiger.foobar.com', port=5432 |
         | Connect To Database Using Custom Params | jaydebeapi | 'oracle.jdbc.driver.OracleDriver', 'my_db_test', 'system', 's3cr3t' |
         | Connect To Database Using Custom Params | oracledb | user="username", password="pass", dsn="localhost/orclpdb" |
@@ -185,36 +254,41 @@ class ConnectionManager(object):
         db_api_2 = importlib.import_module(dbapiModuleName)
         self.db_api_module_name = dbapiModuleName
 
-        db_connect_string = f'db_api_2.connect({db_connect_string})'
+        db_connect_string = f"db_api_2.connect({db_connect_string})"
 
         connection_string_with_hidden_pass = db_connect_string
-        for pass_param_name in ['pass', 'passwd', 'password', 'pwd', 'PWD']:
-            splitted = connection_string_with_hidden_pass.split(pass_param_name + '=')
+        for pass_param_name in ["pass", "passwd", "password", "pwd", "PWD"]:
+            splitted = connection_string_with_hidden_pass.split(pass_param_name + "=")
             if len(splitted) < 2:
                 continue
-            splitted = splitted[1].split(',')
+            splitted = splitted[1].split(",")
             value_to_hide = splitted[0]
             connection_string_with_hidden_pass = connection_string_with_hidden_pass.replace(value_to_hide, "***")
-        logger.info('Executing : Connect To Database Using Custom Params : %s.connect(%s) ' % (dbapiModuleName, connection_string_with_hidden_pass))
+        logger.info(
+            "Executing : Connect To Database Using Custom Params : %s.connect(%s) "
+            % (dbapiModuleName, connection_string_with_hidden_pass)
+        )
 
         self._dbconnection = eval(db_connect_string)
 
-    def connect_to_database_using_custom_connection_string(self, dbapiModuleName=None, db_connect_string=''):
+    def connect_to_database_using_custom_connection_string(self, dbapiModuleName=None, db_connect_string=""):
         """
         Loads the DB API 2.0 module given `dbapiModuleName` then uses it to
         connect to the database using the `db_connect_string`
         (parsed as single connection connection string or URI).
-        
+
         Use `connect_to_database_using_custom_params` for passing
         connection params as named arguments.
 
-        Example usage:        
+        Example usage:
         | Connect To Database Using Custom Connection String | psycopg2 | postgresql://postgres:s3cr3t@tiger.foobar.com:5432/my_db_test |
-        | Connect To Database Using Custom Connection String | oracledb | username/pass@localhost:1521/orclpdb" |        
+        | Connect To Database Using Custom Connection String | oracledb | username/pass@localhost:1521/orclpdb" |
         """
         db_api_2 = importlib.import_module(dbapiModuleName)
         self.db_api_module_name = dbapiModuleName
-        logger.info(f"Executing : Connect To Database Using Custom Connection String : {dbapiModuleName}.connect('{db_connect_string}')")
+        logger.info(
+            f"Executing : Connect To Database Using Custom Connection String : {dbapiModuleName}.connect('{db_connect_string}')"
+        )
         self._dbconnection = db_api_2.connect(db_connect_string)
 
     def disconnect_from_database(self, error_if_no_connection=False):
@@ -227,7 +301,7 @@ class ConnectionManager(object):
         For example:
         | Disconnect From Database | # disconnects from current connection to the database |
         """
-        logger.info('Executing : Disconnect From Database')
+        logger.info("Executing : Disconnect From Database")
         if self._dbconnection is None:
             log_msg = "No open database connection to close"
             if error_if_no_connection:
@@ -239,19 +313,19 @@ class ConnectionManager(object):
 
     def set_auto_commit(self, autoCommit=True):
         """
-        Turn the autocommit on the database connection ON or OFF. 
-        
-        The default behaviour on a newly created database connection is to automatically start a 
-        transaction, which means that database actions that won't work if there is an active 
-        transaction will fail. Common examples of these actions are creating or deleting a database 
-        or database snapshot. By turning on auto commit on the database connection these actions 
+        Turn the autocommit on the database connection ON or OFF.
+
+        The default behaviour on a newly created database connection is to automatically start a
+        transaction, which means that database actions that won't work if there is an active
+        transaction will fail. Common examples of these actions are creating or deleting a database
+        or database snapshot. By turning on auto commit on the database connection these actions
         can be performed.
-        
+
         Example:
         | # Default behaviour, sets auto commit to true
         | Set Auto Commit
         | # Explicitly set the desired state
         | Set Auto Commit | False
         """
-        logger.info('Executing : Set Auto Commit')
+        logger.info("Executing : Set Auto Commit")
         self._dbconnection.autocommit = autoCommit

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -12,12 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import sys
 import inspect
+import sys
+
 from robot.api import logger
 
 
-class Query(object):
+class Query:
     """
     Query handles all the querying done by the Database Library.
     """
@@ -59,7 +60,7 @@ class Query(object):
         cur = None
         try:
             cur = self._dbconnection.cursor()
-            logger.info('Executing : Query  |  %s ' % selectStatement)
+            logger.info("Executing : Query  |  %s " % selectStatement)
             self.__execute_sql(cur, selectStatement)
             allRows = cur.fetchall()
 
@@ -110,7 +111,7 @@ class Query(object):
         cur = None
         try:
             cur = self._dbconnection.cursor()
-            logger.info('Executing : Row Count  |  %s ' % selectStatement)
+            logger.info("Executing : Row Count  |  %s " % selectStatement)
             self.__execute_sql(cur, selectStatement)
             data = cur.fetchall()
             if self.db_api_module_name in ["sqlite3", "ibm_db", "ibm_db_dbi", "pyodbc"]:
@@ -147,12 +148,12 @@ class Query(object):
         cur = None
         try:
             cur = self._dbconnection.cursor()
-            logger.info('Executing : Description  |  %s ' % selectStatement)
+            logger.info("Executing : Description  |  %s " % selectStatement)
             self.__execute_sql(cur, selectStatement)
             description = list(cur.description)
             if sys.version_info[0] < 3:
                 for row in range(0, len(description)):
-                    description[row] = (description[row][0].encode('utf-8'),) + description[row][1:]
+                    description[row] = (description[row][0].encode("utf-8"),) + description[row][1:]
             return description
         finally:
             if cur:
@@ -179,10 +180,10 @@ class Query(object):
         | Delete All Rows From Table | person | True |
         """
         cur = None
-        selectStatement = ("DELETE FROM %s" % tableName)
+        selectStatement = "DELETE FROM %s" % tableName
         try:
             cur = self._dbconnection.cursor()
-            logger.info('Executing : Delete All Rows From Table  |  %s ' % selectStatement)
+            logger.info("Executing : Delete All Rows From Table  |  %s " % selectStatement)
             result = self.__execute_sql(cur, selectStatement)
             if result is not None:
                 if not sansTran:
@@ -201,7 +202,7 @@ class Query(object):
         state before running your tests, or clearing out your test data after running each a test. Set optional input
         `sansTran` to True to run command without an explicit transaction commit or rollback.
 
-        
+
         Sample usage :
         | Execute Sql Script | ${EXECDIR}${/}resources${/}DDL-setup.sql |
         | Execute Sql Script | ${EXECDIR}${/}resources${/}DML-setup.sql |
@@ -253,28 +254,28 @@ class Query(object):
         Using optional `sansTran` to run command without an explicit transaction commit or rollback:
         | Execute Sql Script | ${EXECDIR}${/}resources${/}DDL-setup.sql | True |
         """
-        with open(sqlScriptFileName, encoding='UTF-8') as sql_file:
+        with open(sqlScriptFileName, encoding="UTF-8") as sql_file:
             cur = None
             try:
                 statements_to_execute = []
                 cur = self._dbconnection.cursor()
-                logger.info('Executing : Execute SQL Script  |  %s ' % sqlScriptFileName)
-                current_statement = ''
+                logger.info("Executing : Execute SQL Script  |  %s " % sqlScriptFileName)
+                current_statement = ""
                 inside_statements_group = False
 
                 for line in sql_file:
                     line = line.strip()
-                    if line.startswith('#') or line.startswith('--') or line == "/":
+                    if line.startswith("#") or line.startswith("--") or line == "/":
                         continue
                     if line.lower().startswith("begin"):
                         inside_statements_group = True
-                    
+
                     # semicolons inside the line? use them to separate statements
                     # ... but not if they are inside a begin/end block (aka. statements group)
-                    sqlFragments = line.split(';')
+                    sqlFragments = line.split(";")
                     # no semicolons
                     if len(sqlFragments) == 1:
-                        current_statement += line + ' '
+                        current_statement += line + " "
                         continue
                     quotes = 0
                     # "select * from person;" -> ["select..", ""]
@@ -289,7 +290,7 @@ class Query(object):
                             inside_statements_group = False
                         elif sqlFragment.lower().startswith("begin"):
                             inside_statements_group = True
-                        
+
                         # check if the semicolon is a part of the value (quoted string)
                         quotes += sqlFragment.count("'")
                         quotes -= sqlFragment.count("\\'")
@@ -297,17 +298,17 @@ class Query(object):
                         inside_quoted_string = quotes % 2 != 0
                         if inside_quoted_string:
                             sqlFragment += ";"  # restore the semicolon
-                        
+
                         current_statement += sqlFragment
                         if not inside_statements_group and not inside_quoted_string:
                             statements_to_execute.append(current_statement.strip())
-                            current_statement = ''
+                            current_statement = ""
                             quotes = 0
 
                 current_statement = current_statement.strip()
                 if len(current_statement) != 0:
                     statements_to_execute.append(current_statement)
-                    
+
                 for statement in statements_to_execute:
                     logger.info(f"Executing statement from script file: {statement}")
                     omit_semicolon = not statement.lower().endswith("end;")
@@ -338,7 +339,7 @@ class Query(object):
         cur = None
         try:
             cur = self._dbconnection.cursor()
-            logger.info('Executing : Execute SQL String  |  %s ' % sqlString)
+            logger.info("Executing : Execute SQL String  |  %s " % sqlString)
             self.__execute_sql(cur, sqlString)
             if not sansTran:
                 self._dbconnection.commit()
@@ -364,7 +365,7 @@ class Query(object):
         E.g. calling a procedure in *PostgreSQL* returns even a single value of an OUT param as a result set.
 
         Set optional input `sansTran` to True to run command without an explicit transaction commit or rollback.
-        
+
         Simple example:
         | @{Params} = | Create List | Jerry | out_second_name |
         | @{Param values}    @{Result sets} = | Call Stored Procedure | Get_second_name | ${Params} |
@@ -390,15 +391,15 @@ class Query(object):
             spParams = []
         cur = None
         try:
-            logger.info('Executing : Call Stored Procedure  |  %s  |  %s ' % (spName, spParams))
+            logger.info("Executing : Call Stored Procedure  |  %s  |  %s " % (spName, spParams))
             if self.db_api_module_name == "pymssql":
                 cur = self._dbconnection.cursor(as_dict=False)
             else:
                 cur = self._dbconnection.cursor()
-            
+
             param_values = []
             result_sets = []
-            
+
             if self.db_api_module_name == "pymysql":
                 cur.callproc(spName, spParams)
 
@@ -419,7 +420,7 @@ class Query(object):
             elif self.db_api_module_name in ["oracledb", "cx_Oracle"]:
                 # check if "CURSOR" params were passed - they will be replaced
                 # with cursor variables for storing the result sets
-                params_substituted= spParams.copy()
+                params_substituted = spParams.copy()
                 cursor_params = []
                 for i in range(0, len(spParams)):
                     if spParams[i] == "CURSOR":
@@ -434,7 +435,7 @@ class Query(object):
                 cur = self._dbconnection.cursor()
                 # check if "CURSOR" params were passed - they will be replaced
                 # with cursor variables for storing the result sets
-                params_substituted= spParams.copy()
+                params_substituted = spParams.copy()
                 cursor_params = []
                 for i in range(0, len(spParams)):
                     if spParams[i] == "CURSOR":
@@ -453,13 +454,15 @@ class Query(object):
                         while result_sets_available:
                             result_sets.append(list(cur.fetchall()))
                             result_sets_available = cur.nextset()
-                    else:                        
+                    else:
                         result_set = cur.fetchall()
                         result_sets.append(list(result_set))
 
             else:
-                logger.info(f"CAUTION! Calling a stored procedure for '{self.db_api_module_name}' is not tested, "
-                            "results might be invalid!")
+                logger.info(
+                    f"CAUTION! Calling a stored procedure for '{self.db_api_module_name}' is not tested, "
+                    "results might be invalid!"
+                )
                 cur = self._dbconnection.cursor()
                 param_values = cur.callproc(spName, spParams)
                 logger.info("Reading the procedure results..")
@@ -470,11 +473,11 @@ class Query(object):
                         result_set.append(row)
                     if result_set:
                         result_sets.append(list(result_set))
-                    if hasattr(cur, 'nextset') and inspect.isroutine(cur.nextset):
+                    if hasattr(cur, "nextset") and inspect.isroutine(cur.nextset):
                         result_sets_available = cur.nextset()
                     else:
                         result_sets_available = False
-                
+
             if not sansTran:
                 self._dbconnection.commit()
 

--- a/src/DatabaseLibrary/version.py
+++ b/src/DatabaseLibrary/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.3.1'
+VERSION = "1.3.1"


### PR DESCRIPTION
I have several ideas for improvements and fixes in this repository. However I think it would be beneficial to follow the same coding standard when contributing to the repository first. For that purpose I have added precommit configuration and run it on all files.

To use it when developing locally:

Install precommit package:
```
pip install pre-commit
```

Install in the repository root:
```
pre-commit install
```

From now on every commit will run black and isort tools to autoformat the code (first run after installation will take the longest, next ones should be seconds). If the formatters end up formatting the file, the commit will be cancelled and need to be redone.

In the future we can add Github action to verify if new PRs used precommits to autoformat the files.