### PR TITLE
Parameters

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -60,7 +60,7 @@ class Query(object):
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Query  |  %s ' % selectStatement)
-            self.__execute_sql(cur, selectStatement)
+            self.__execute_sql(cur, selectStatement, parameters=parameters)
             allRows = cur.fetchall()
 
             if returnAsDict:
@@ -111,7 +111,7 @@ class Query(object):
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Row Count  |  %s ' % selectStatement)
-            self.__execute_sql(cur, selectStatement)
+            self.__execute_sql(cur, selectStatement, parameters=parameters)
             data = cur.fetchall()
             if self.db_api_module_name in ["sqlite3", "ibm_db", "ibm_db_dbi", "pyodbc"]:
                 rowCount = len(data)
@@ -148,7 +148,7 @@ class Query(object):
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Description  |  %s ' % selectStatement)
-            self.__execute_sql(cur, selectStatement)
+            self.__execute_sql(cur, selectStatement, parameters=parameters)
             description = list(cur.description)
             if sys.version_info[0] < 3:
                 for row in range(0, len(description)):
@@ -339,7 +339,7 @@ class Query(object):
         try:
             cur = self._dbconnection.cursor()
             logger.info('Executing : Execute SQL String  |  %s ' % sqlString)
-            self.__execute_sql(cur, sqlString)
+            self.__execute_sql(cur, sqlString, parameters=parameters)
             if not sansTran:
                 self._dbconnection.commit()
         finally:

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -22,7 +22,7 @@ class Query(object):
     Query handles all the querying done by the Database Library.
     """
 
-    def query(self, selectStatement, sansTran=False, returnAsDict=False):
+    def query(self, selectStatement, sansTran=False, returnAsDict=False, parameters=None):
         """
         Uses the input `selectStatement` to query for the values that will be returned as a list of tuples. Set optional
         input `sansTran` to True to run command without an explicit transaction commit or rollback.
@@ -80,7 +80,7 @@ class Query(object):
                 if not sansTran:
                     self._dbconnection.rollback()
 
-    def row_count(self, selectStatement, sansTran=False):
+    def row_count(self, selectStatement, sansTran=False, parameters=None):
         """
         Uses the input `selectStatement` to query the database and returns the number of rows from the query. Set
         optional input `sansTran` to True to run command without an explicit transaction commit or rollback.
@@ -123,7 +123,7 @@ class Query(object):
                 if not sansTran:
                     self._dbconnection.rollback()
 
-    def description(self, selectStatement, sansTran=False):
+    def description(self, selectStatement, sansTran=False, parameters=None):
         """
         Uses the input `selectStatement` to query a table in the db which will be used to determine the description. Set
         optional input `sansTran` to True to run command without an explicit transaction commit or rollback.
@@ -319,7 +319,7 @@ class Query(object):
                     if not sansTran:
                         self._dbconnection.rollback()
 
-    def execute_sql_string(self, sqlString, sansTran=False):
+    def execute_sql_string(self, sqlString, sansTran=False, parameters=None):
         """
         Executes the sqlString as SQL commands. Useful to pass arguments to your sql. Set optional input `sansTran` to
         True to run command without an explicit transaction commit or rollback.
@@ -484,7 +484,7 @@ class Query(object):
                 if not sansTran:
                     self._dbconnection.rollback()
 
-    def __execute_sql(self, cur, sql_statement, omit_trailing_semicolon=None):
+    def __execute_sql(self, cur, sql_statement, omit_trailing_semicolon=None, parameters=None):
         """
         Runs the `sql_statement` using `cur` as Cursor object.
         Use `omit_trailing_semicolon` parameter (bool) for explicite instruction,
@@ -496,5 +496,7 @@ class Query(object):
             omit_trailing_semicolon = self.omit_trailing_semicolon
         if omit_trailing_semicolon:
             sql_statement = sql_statement.rstrip(";")
+        if parameters is None:
+            parameters = []
         logger.debug(f"Executing sql: {sql_statement}")
-        return cur.execute(sql_statement)
+        return cur.execute(sql_statement, parameters)

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -18,11 +18,15 @@ SQL Statement Ending Without Semicolon Works
 
 SQL Statement With Parameters Works
     @{params}=    Create List    2
-    TRY
-        ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=${params}
-    EXCEPT
+    
+    IF  "${DB_MODULE}" in ["oracledb"]
         ${output}=    Query    SELECT * FROM person WHERE id < :id    parameters=${params}
+    ELSE IF  "${DB_MODULE}" in ["sqlite3", "pyodbc"]
+        ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=${params}
+    ELSE
+        ${output}=    Query    SELECT * FROM person WHERE id < %s    parameters=${params}    
     END
+    
     Length Should Be    ${output}    1    
 
 Create Person Table

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -18,7 +18,11 @@ SQL Statement Ending Without Semicolon Works
 
 SQL Statement With Parameters Works
     @{params}=    Create List    2
-    ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=${params}
+    TRY
+        ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=${params}
+    EXCEPT
+        ${output}=    Query    SELECT * FROM person WHERE id < :id    parameters=${params}
+    END
     Length Should Be    ${output}    1    
 
 Create Person Table

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -17,7 +17,8 @@ SQL Statement Ending Without Semicolon Works
     Query    SELECT * FROM person;
 
 SQL Statement With Parameters Works
-    ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=[1]
+    @{params}=    Create List    2
+    ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=${params}
     Length Should Be    ${output}    1    
 
 Create Person Table

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -16,6 +16,10 @@ SQL Statement Ending With Semicolon Works
 SQL Statement Ending Without Semicolon Works
     Query    SELECT * FROM person;
 
+SQL Statement With Parameters Works
+    ${output}=    Query    SELECT * FROM person WHERE id < ?    parameters=[1]
+    Length Should Be    ${output}    1    
+
 Create Person Table
     [Setup]    Log    No setup for this test
     ${output}=    Create Person Table


### PR DESCRIPTION
#146 

Add an optional argument to a number of existing keywords for passing sql parameters.

These can then be inserted by the driver, avoiding the need to use variable substitution.

See also https://peps.python.org/pep-0249/#id20.
