### PR TITLE
Allow tuple type for parameters argument

### DIFF
--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -15,7 +15,7 @@
 import inspect
 import re
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from robot.api import logger
 
@@ -31,7 +31,7 @@ class Query:
         sansTran: bool = False,
         returnAsDict: bool = False,
         alias: Optional[str] = None,
-        parameters: Optional[List] = None,
+        parameters: None | List | Tuple = None,
     ):
         """
         Runs a query with the ``selectStatement`` and returns the result as a list of rows.
@@ -48,6 +48,10 @@ class Query:
         depending on the database client):
         | @{parameters} | Create List |  person |
         | Query | SELECT * FROM %s | parameters=${parameters} |
+
+        Use optional ``parameters`` with tuple datatype for query variable substitution when using pymsssql driver
+        | ${parameters} | Evaluate | ('${date}', '${person_id}') |
+        | Execute Sql String | UPDATE Person SET DateCreated=%s WHERE Id=%s | parameters=${parameters} |
 
         Use optional ``sansTran`` to run command without an explicit transaction commit or rollback:
         | @{queryResults} | Query | SELECT * FROM person | True |
@@ -98,7 +102,7 @@ class Query:
         selectStatement: str,
         sansTran: bool = False,
         alias: Optional[str] = None,
-        parameters: Optional[List] = None,
+        parameters: None | List | Tuple = None,
     ):
         """
         Uses the input ``selectStatement`` to query the database and returns the number of rows from the query.
@@ -137,7 +141,7 @@ class Query:
         selectStatement: str,
         sansTran: bool = False,
         alias: Optional[str] = None,
-        parameters: Optional[List] = None,
+        parameters: None | List | Tuple = None,
     ):
         """
         Uses the input ``selectStatement`` to query a table in the db which will be used to determine the description.
@@ -364,7 +368,7 @@ class Query:
         sqlString: str,
         sansTran: bool = False,
         alias: Optional[str] = None,
-        parameters: Optional[List] = None,
+        parameters: None | List | Tuple = None,
         omitTrailingSemicolon: Optional[bool] = None,
     ):
         """
@@ -547,7 +551,11 @@ class Query:
                 db_connection.client.rollback()
 
     def __execute_sql(
-        self, cur, sql_statement: str, omit_trailing_semicolon: Optional[bool] = None, parameters: Optional[List] = None
+        self,
+        cur,
+        sql_statement: str,
+        omit_trailing_semicolon: Optional[bool] = None,
+        parameters: None | List | Tuple = None,
     ):
         """
         Runs the `sql_statement` using `cur` as Cursor object.


### PR DESCRIPTION
When using the pymssql driver, a parameters argument of type tuple is required to do variable substitution.
This pull request makes this possible by allowing tuple type for parameters argument for all keywords.
I also added an example to the documentation of the "query" keyword.
The file has been reformatted with black.