### PR TITLE
New keywords with assertion engine and require min. Python 3.8 and RF 5.0.1

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,11 +13,8 @@ jobs:
       matrix:
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.7'
-            rf-version: '3.2.2'
-          - os: 'ubuntu-latest'
             python-version: '3.8'
-            rf-version: '4.1.3'
+            rf-version: '5.0.1'
           - os: 'ubuntu-latest'
             python-version: '3.9'
             rf-version: '5.0.1'
@@ -29,7 +26,7 @@ jobs:
             rf-version: '6.1.1'
           - os: 'ubuntu-latest'
             python-version: '3.12'
-            rf-version: '7.0a1'
+            rf-version: '7.0.1'
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=61.0",
-    "robotframework"
+    "robotframework",
+    "robotframework-assertion-engine"
     ]
 build-backend = "setuptools.build_meta"
 
@@ -11,10 +12,11 @@ authors = [{name="Franz Allan Valencia See", email="franz.see@gmail.com"},
 ]
 description = "Database Library for Robot Framework"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8.1"
 dependencies = [
     "robotframework",
-    "robotframework-excellib"
+    "robotframework-excellib",
+    "robotframework-assertion-engine"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61.0",
-    "robotframework",
+    "robotframework>=5.0.1",
     "robotframework-assertion-engine"
     ]
 build-backend = "setuptools.build_meta"
@@ -14,7 +14,7 @@ description = "Database Library for Robot Framework"
 readme = "README.md"
 requires-python = ">=3.8.1"
 dependencies = [
-    "robotframework",
+    "robotframework>=5.0.1",
     "robotframework-excellib",
     "robotframework-assertion-engine"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 robotframework
 robotframework-excellib
+robotframework-assertion-engine
+psycopg2-binary
 pre-commit
 build
 twine

--- a/src/DatabaseLibrary/__init__.py
+++ b/src/DatabaseLibrary/__init__.py
@@ -27,17 +27,20 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     The Database Library for [https://robotframework.org|Robot Framework] allows you to query a database and verify the results.
     It requires an appropriate *Python module to be installed separately* - depending on your database, like e.g. `oracledb` or `pymysql`.
 
-    == Requirements ==
+    == Table of contents ==
+    %TOC%
+
+    = Requirements =
     - Python
     - Robot Framework
     - Python database module you're going to use - e.g. `oracledb`
 
-    == Installation ==
+    = Installation =
     | pip install robotframework-databaselibrary
     Don't forget to install the required Python database module!
 
-    == Usage example ==
-    === Basic usage ===
+    = Usage example =
+    == Basic usage ==
     | *** Settings ***
     | Library       DatabaseLibrary
     | Test Setup    Connect To My Oracle DB
@@ -65,7 +68,7 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     |     Check If Not Exists In Database    ${sql}
     |
 
-    === Handling multiple database connections ===
+    == Handling multiple database connections ==
     | *** Settings ***
     | Library          DatabaseLibrary
     | Test Setup       Connect To All Databases
@@ -90,11 +93,13 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     |     Execute Sql String    drop table XYZ
     |
 
-    == Inline assertions ==
+    = Inline assertions =
     Keywords that accept arguments ``assertion_operator`` <`AssertionOperator`> and ``expected_value``
     perform a check according to the specified condition - using the [https://github.com/MarketSquare/AssertionEngine|Assertion Engine].
+    |   Check Row Count       SELECT id FROM person            ==         2
+    |   Check Query Result    SELECT first_name FROM person    contains   Allan
 
-    == Database modules compatibility ==
+    = Database modules compatibility =
     The library is basically compatible with any [https://peps.python.org/pep-0249|Python Database API Specification 2.0] module.
 
     However, the actual implementation in existing Python modules is sometimes quite different, which requires custom handling in the library.

--- a/src/DatabaseLibrary/__init__.py
+++ b/src/DatabaseLibrary/__init__.py
@@ -91,8 +91,8 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     |
 
     == Inline assertions ==
-    Keywords that accept arguments ``assertion_operator`` <`AssertionOperator`> and ``assertion_value``
-    perform a check according to the specified condition.
+    Keywords that accept arguments ``assertion_operator`` <`AssertionOperator`> and ``expected_value``
+    perform a check according to the specified condition - using the [https://github.com/MarketSquare/AssertionEngine|Assertion Engine].
 
     == Database modules compatibility ==
     The library is basically compatible with any [https://peps.python.org/pep-0249|Python Database API Specification 2.0] module.

--- a/src/DatabaseLibrary/__init__.py
+++ b/src/DatabaseLibrary/__init__.py
@@ -89,6 +89,11 @@ class DatabaseLibrary(ConnectionManager, Query, Assertion):
     |     Switch Database    mysql
     |     Execute Sql String    drop table XYZ
     |
+
+    == Inline assertions ==
+    Keywords that accept arguments ``assertion_operator`` <`AssertionOperator`> and ``assertion_value``
+    perform a check according to the specified condition.
+
     == Database modules compatibility ==
     The library is basically compatible with any [https://peps.python.org/pep-0249|Python Database API Specification 2.0] module.
 

--- a/src/DatabaseLibrary/assertion.py
+++ b/src/DatabaseLibrary/assertion.py
@@ -338,7 +338,7 @@ class Assertion:
         | Check Query Result | SELECT first_name, last_name FROM person | *==* | Schneider | row=1 | col=1 |
         | Check Query Result | SELECT id FROM person WHERE first_name = 'John' | *==* | 2 | # Fails, if query returns an integer value |
         | Check Query Result | SELECT id FROM person WHERE first_name = 'John' | *==* | ${2} | # Works, if query returns an integer value |
-        | Check Query Result | SELECT first_name FROM person | *equal* | Franz Allan | 2 | assertion_message=my error message |
+        | Check Query Result | SELECT first_name FROM person | *equal* | Franz Allan | assertion_message=my error message |
         | Check Query Result | SELECT first_name FROM person | *inequal* | John | alias=my_alias |
         | Check Query Result | SELECT first_name FROM person | *contains* | Allan | sansTran=True |
         | @{parameters} | Create List |  John |

--- a/src/DatabaseLibrary/assertion.py
+++ b/src/DatabaseLibrary/assertion.py
@@ -107,6 +107,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         Check if any rows are returned from the submitted ``selectStatement``. If there are, then this will throw an
         AssertionError.
 
@@ -144,6 +147,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         Check if the number of rows returned from ``selectStatement`` is equal to the value submitted. If not, then this
         will throw an AssertionError.
 
@@ -182,6 +188,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         Check if the number of rows returned from ``selectStatement`` is greater than the value submitted. If not, then
         this will throw an AssertionError.
 
@@ -220,6 +229,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         Check if the number of rows returned from ``selectStatement`` is less than the value submitted. If not, then this
         will throw an AssertionError.
 

--- a/src/DatabaseLibrary/assertion.py
+++ b/src/DatabaseLibrary/assertion.py
@@ -31,6 +31,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         Check if any row would be returned by given the input ``selectStatement``. If there are no results, then this will
         throw an AssertionError.
 
@@ -68,6 +71,9 @@ class Assertion:
         parameters: Optional[Tuple] = None,
     ):
         """
+        *DEPRECATED* Use new `Check Row Count` keyword with assertion engine instead.
+        The deprecated keyword will be removed in future versions.
+
         This is the negation of `check_if_exists_in_database`.
 
         Check if no rows would be returned by given the input ``selectStatement``. If there are any results, then this

--- a/src/DatabaseLibrary/query.py
+++ b/src/DatabaseLibrary/query.py
@@ -126,8 +126,11 @@ class Query:
             self.__execute_sql(cur, selectStatement, parameters=parameters)
             data = cur.fetchall()
             if db_connection.module_name in ["sqlite3", "ibm_db", "ibm_db_dbi", "pyodbc"]:
-                return len(data)
-            return cur.rowcount
+                current_row_count = len(data)
+            else:
+                current_row_count = cur.rowcount
+            logger.info(f"Retrieved {current_row_count} rows")
+            return current_row_count
         finally:
             if cur and not sansTran:
                 db_connection.client.rollback()

--- a/test/tests/common_tests/assertion_error_messages.robot
+++ b/test/tests/common_tests/assertion_error_messages.robot
@@ -103,3 +103,16 @@ Verify Row Count Is Greater Than X Fails With Message
     ...    Row Count Is Greater Than X
     ...    ${Existing Select}    1
     ...    msg=${Error Message}
+
+Check Row Count With Assertion Engine Fails
+    ${expected value}=    Set Variable    5
+    ${expected error}=    Catenate
+    ...    Wrong row count: '1' (int) should be '${expected value}' (int)
+    Run Keyword And Expect Error
+    ...    ${expected error}
+    ...    Check Row Count    ${Existing Select}    equals    ${expected value}
+
+Check Row Count With Assertion Engine Fails With Message
+    Run Keyword And Expect Error    ${Error Message}
+    ...    Check Row Count    ${Existing Select}    less than    1
+    ...    assertion_message=${Error Message}

--- a/test/tests/common_tests/assertion_error_messages.robot
+++ b/test/tests/common_tests/assertion_error_messages.robot
@@ -116,3 +116,18 @@ Check Row Count With Assertion Engine Fails With Message
     Run Keyword And Expect Error    ${Error Message}
     ...    Check Row Count    ${Existing Select}    less than    1
     ...    assertion_message=${Error Message}
+
+
+Check Query Result With Assertion Engine Fails
+    ${expected value}=    Set Variable    ${5}
+    ${expected error}=    Catenate
+    ...    Wrong query result: '1' (int) should be '${expected value}' (int)
+    Run Keyword And Expect Error
+    ...    ${expected error}
+    ...    Check Query Result    ${Existing Select}    equals    ${expected value}
+
+
+Check Query Result With Assertion Engine Fails With Message
+    Run Keyword And Expect Error    ${Error Message}
+    ...    Check Query Result    ${Existing Select}    less than    ${1}
+    ...    assertion_message=${Error Message}

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -66,6 +66,21 @@ Retrieve Row Count
 Check Row Count With Assertion Engine
     Check Row Count    SELECT id FROM person    ==    2
 
+Check Query Result With Assertion Engine
+    Check Query Result    SELECT first_name FROM person    contains   Allan
+
+Check Query Result With Assertion Engine - Different Row And Col
+    Check Query Result    SELECT first_name, last_name, id FROM person    >=   ${2}    row=1    col=2
+
+Check Query Result With Assertion Engine - Row Out Of Range
+    Run Keyword And Expect Error    Checking row '2' is not possible, as query results contain 2 rows only!
+    ...    Check Query Result    SELECT first_name FROM person    ==   Blah    row=2
+
+Check Query Result With Assertion Engine - Col Out Of Range
+    Run Keyword And Expect Error    Checking column '5' is not possible, as query results contain 2 columns only!
+    ...    Check Query Result    SELECT id, first_name FROM person    ==   Blah    col=5
+
+
 Retrieve records from person table
     ${output}=    Execute SQL String    SELECT * FROM person
     Log    ${output}

--- a/test/tests/common_tests/basic_tests.robot
+++ b/test/tests/common_tests/basic_tests.robot
@@ -63,6 +63,9 @@ Retrieve Row Count
     Log    ${output}
     Should Be Equal As Strings    ${output}    2
 
+Check Row Count With Assertion Engine
+    Check Row Count    SELECT id FROM person    ==    2
+
 Retrieve records from person table
     ${output}=    Execute SQL String    SELECT * FROM person
     Log    ${output}


### PR DESCRIPTION
There are 2 new keywords using the Assertion Engine:
- ``Check Row Count``
- ``Check Query Result``

The [Row Count](https://marketsquare.github.io/Robotframework-Database-Library/#Row%20Count) keyword is left untouched - just for returning the row count, without any checks.
The following keywords are marked as deprecated now and will be removed in future versions:
- [Row Count Is 0](https://marketsquare.github.io/Robotframework-Database-Library/#Row%20Count%20Is%200)
- [Row Count Is Equal To X](https://marketsquare.github.io/Robotframework-Database-Library/#Row%20Count%20Is%20Equal%20To%20X)
- [Row Count Is Greater Than X](https://marketsquare.github.io/Robotframework-Database-Library/#Row%20Count%20Is%20Greater%20Than%20X)
- [Row Count Is Less Than X](https://marketsquare.github.io/Robotframework-Database-Library/#Row%20Count%20Is%20Less%20Than%20X)
- [Check If Exists In Database](https://marketsquare.github.io/Robotframework-Database-Library/#Check%20If%20Exists%20In%20Database)
- [Check If Not Exists In Database](https://marketsquare.github.io/Robotframework-Database-Library/#Check%20If%20Not%20Exists%20In%20Database)