### PR TITLE
Calling a stored procedure in MSSQL - special handling of OUT params

### DIFF
--- a/test/resources/create_stored_procedures_mssql.sql
+++ b/test/resources/create_stored_procedures_mssql.sql
@@ -50,3 +50,20 @@ BEGIN
 PRINT 'Condition is false';
 END
 END;
+
+DROP PROCEDURE IF EXISTS return_out_param_without_result_sets;
+CREATE PROCEDURE 
+return_out_param_without_result_sets
+@my_input VARCHAR(20),
+@my_output INT OUTPUT
+AS
+BEGIN
+ IF @my_input = 'give me 1'
+    BEGIN
+        SELECT @my_output = 1;
+    END
+    ELSE
+    BEGIN
+        SELECT @my_output = 0;
+    END
+END;

--- a/test/tests/common_tests/stored_procedures.robot
+++ b/test/tests/common_tests/stored_procedures.robot
@@ -91,6 +91,22 @@ Procedure Returns Multiple Result Sets
 Procedure With IF/ELSE Block
     Call Stored Procedure    check_condition
 
+MSSQL Procedure Returns OUT Param Without Result Sets
+    IF    "${DB_MODULE}" not in ["pymssql"]
+        Skip    This test is valid for pymssql only
+    END
+    @{params}=    Create List    give me 1    
+    @{out_params}=    Create List    ${9}    
+    ${param values}    ${result sets}=    Call Stored Procedure    return_out_param_without_result_sets    
+    ...    ${params}    additional_output_params=${out_params}
+    Should Be Empty    ${result sets}
+    Should Be Equal As Integers    ${param values}[1]    1
+    @{params}=    Create List    give me 0
+    ${param values}    ${result sets}=    Call Stored Procedure    return_out_param_without_result_sets    
+    ...    ${params}    additional_output_params=${out_params}
+        Should Be Empty    ${result sets}
+    Should Be Equal As Integers    ${param values}[1]    0
+
 
 *** Keywords ***
 Create And Fill Tables And Stored Procedures


### PR DESCRIPTION
The _pymssql_ driver doesn't natively support getting the OUT parameter values after calling a procedure.
This requires special handling of OUT parameters using the `additional_output_params` argument.

Calling the procedure in Robot Framework requires putting the IN parameters as usual in the `spParams` argument, but the sample values of OUT parameters must be put in the argument `additional_output_params`.

The library uses the sample values in the `additional_output_params` list to determine the number and the type of OUT parameters - so they are type-sensitive, the type must be the same as in the procedure itself.