### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 "Keyword docs" = "http://marketsquare.github.io/Robotframework-Database-Library/"
 
 [tool.setuptools.dynamic]
-version = {attr = "DatabaseLibrary.__version__"}
+version = {attr = "DatabaseLibrary/version.py:VERSION"}
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Keyword documentation doesn’t have version number and I think it’s caused because pointing to a wrong place in toml file.